### PR TITLE
publishing creates new snapshot only for unpublished content

### DIFF
--- a/Consumer/CreateSnapshotConsumer.php
+++ b/Consumer/CreateSnapshotConsumer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Symbio\OrangeGate\PageBundle\Consumer;
+
+use Sonata\PageBundle\Model\SnapshotManagerInterface;
+use Sonata\PageBundle\Model\PageManagerInterface;
+use Sonata\NotificationBundle\Consumer\ConsumerInterface;
+use Sonata\NotificationBundle\Consumer\ConsumerEvent;
+use Sonata\PageBundle\Model\TransformerInterface;
+
+/**
+ * Consumer class to generate a snapshot
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+class CreateSnapshotConsumer implements ConsumerInterface
+{
+    protected $snapshotManager;
+
+    protected $pageManager;
+
+    protected $transformer;
+
+    /**
+     * @param SnapshotManagerInterface $snapshotManager
+     * @param PageManagerInterface     $pageManager
+     * @param TransformerInterface     $transformer
+     */
+    public function __construct(SnapshotManagerInterface $snapshotManager, PageManagerInterface $pageManager, TransformerInterface $transformer)
+    {
+        $this->snapshotManager = $snapshotManager;
+        $this->pageManager     = $pageManager;
+        $this->transformer     = $transformer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ConsumerEvent $event)
+    {
+        $pageId = $event->getMessage()->getValue('pageId');
+
+        $page = $this->pageManager->findOneBy(array('id' => $pageId));
+
+        if (!$page || $page->getEdited() === false) {
+            return;
+        }
+
+        // start a transaction
+        $this->snapshotManager->getConnection()->beginTransaction();
+
+        // creating snapshot
+        $snapshot = $this->transformer->create($page);
+
+        // update the page status
+        $page->setEdited(false);
+        $this->pageManager->save($page);
+
+        // save the snapshot
+        $this->snapshotManager->save($snapshot);
+        $this->snapshotManager->enableSnapshots(array($snapshot));
+
+        // commit the changes
+        $this->snapshotManager->getConnection()->commit();
+    }
+}

--- a/Consumer/CreateSnapshotsConsumer.php
+++ b/Consumer/CreateSnapshotsConsumer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symbio\OrangeGate\PageBundle\Consumer;
+
+use Sonata\PageBundle\Model\PageManagerInterface;
+
+use Sonata\NotificationBundle\Backend\BackendInterface;
+use Sonata\NotificationBundle\Consumer\ConsumerInterface;
+use Sonata\NotificationBundle\Consumer\ConsumerEvent;
+
+/**
+ * Consumer class to generate snapshots
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+class CreateSnapshotsConsumer implements ConsumerInterface
+{
+    protected $asyncBackend;
+
+    protected $runtimeBackend;
+
+    protected $pageInterface;
+
+    /**
+     * @param BackendInterface     $asyncBackend
+     * @param BackendInterface     $runtimeBackend
+     * @param PageManagerInterface $pageManager
+     */
+    public function __construct(BackendInterface $asyncBackend, BackendInterface $runtimeBackend, PageManagerInterface $pageManager)
+    {
+        $this->asyncBackend   = $asyncBackend;
+        $this->runtimeBackend = $runtimeBackend;
+        $this->pageManager    = $pageManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ConsumerEvent $event)
+    {
+        $pages = $this->pageManager->findBy(array(
+            'site' => $event->getMessage()->getValue('siteId'),
+            'edited' => true,
+        ));
+
+        $backend = $event->getMessage()->getValue('mode') == 'async' ? $this->asyncBackend : $this->runtimeBackend;
+
+        foreach ($pages as $page) {
+            $backend->createAndPublish('sonata.page.create_snapshot', array(
+                'pageId' => $page->getId()
+            ));
+        }
+    }
+}

--- a/DependencyInjection/Compiler/CreateSnapshotConsumerCompilerPass.php
+++ b/DependencyInjection/Compiler/CreateSnapshotConsumerCompilerPass.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jiri.bazant
+ * Date: 26.10.15
+ * Time: 14:31
+ */
+
+namespace Symbio\OrangeGate\PageBundle\DependencyInjection\Compiler;
+
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+class CreateSnapshotConsumerCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('sonata.page.notification.create_snapshot')) {
+            $definition = $container->getDefinition('sonata.page.notification.create_snapshot');
+            $definition->setClass('Symbio\OrangeGate\PageBundle\Consumer\CreateSnapshotConsumer');
+        }
+
+        if ($container->hasDefinition('sonata.page.notification.create_snapshots')) {
+            $definition = $container->getDefinition('sonata.page.notification.create_snapshots');
+            $definition->setClass('Symbio\OrangeGate\PageBundle\Consumer\CreateSnapshotsConsumer');
+        }
+    }
+}

--- a/SymbioOrangeGatePageBundle.php
+++ b/SymbioOrangeGatePageBundle.php
@@ -11,6 +11,7 @@
 namespace Symbio\OrangeGate\PageBundle;
 
 use Symbio\OrangeGate\PageBundle\DependencyInjection\Compiler\AddSitePoolCompilerPass;
+use Symbio\OrangeGate\PageBundle\DependencyInjection\Compiler\CreateSnapshotConsumerCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -38,5 +39,6 @@ class SymbioOrangeGatePageBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new AddSitePoolCompilerPass());
+        $container->addCompilerPass(new CreateSnapshotConsumerCompilerPass());
     }
 }


### PR DESCRIPTION
There is update of two Classes:
1. CreateSnapshotConsumer (original placement sonata-project/page-bundle/Consumer/CreateSnapshotConsumer.php) line 45 
2. CreateSnapshotsConsumer (original placement sonata-project/page-bundle/Consumer/CreateSnapshotsConsumer.php) line 43

For "whole site at one click publishing" only one of them is needed, the other one is in fact redundant. The first one however takes care of single page and page subsets publishing. Second one is on the other hand a bit faster.

There is however still lot of place for speed and memory usage optimization. E.g. page objects are created from db multiple times.
