### PR TITLE
Generate relative url (without host) instead absolute url

### DIFF
--- a/Resources/views/PageAdmin/base_tree.html.twig
+++ b/Resources/views/PageAdmin/base_tree.html.twig
@@ -95,7 +95,7 @@
 
                                     {% if page is defined %}
                                         <li>
-                                            <a href="{{ url('admin_sonata_page_page_compose', {'id': page.id}) }}">
+                                            <a href="{{ path('admin_sonata_page_page_compose', {'id': page.id}) }}">
                                                 <i class="fa fa-magic"></i>
                                                 {{ 'header.compose_page'|trans({}, 'SonataPageBundle')}}
                                             </a>
@@ -117,7 +117,7 @@
                                 {% endif %}
 
                                 {% if app.security and app.security.token and is_granted('ROLE_PREVIOUS_ADMIN') %}
-                                    <li><a href="{{ url('homepage', {'_switch_user': '_exit'}) }}">{{ "header.switch_user_exit"|trans({}, 'SonataPageBundle')}}</a></li>
+                                    <li><a href="{{ path('homepage', {'_switch_user': '_exit'}) }}">{{ "header.switch_user_exit"|trans({}, 'SonataPageBundle')}}</a></li>
                                 {% endif %}
 
                             </ul>

--- a/Resources/views/base_layout.html.twig
+++ b/Resources/views/base_layout.html.twig
@@ -95,7 +95,7 @@
 
                                     {% if page is defined %}
                                         <li>
-                                            <a href="{{ url('admin_orangegate_page_page_compose', {'id': page.id}) }}">
+                                            <a href="{{ path('admin_orangegate_page_page_compose', {'id': page.id}) }}">
                                                 <i class="fa fa-magic"></i>
                                                 {{ 'header.compose_page'|trans({}, 'SonataPageBundle')}}
                                             </a>
@@ -117,7 +117,7 @@
                                 {% endif %}
 
                                 {% if app.security and app.security.token and is_granted('ROLE_PREVIOUS_ADMIN') %}
-                                    <li><a href="{{ url('homepage', {'_switch_user': '_exit'}) }}">{{ "header.switch_user_exit"|trans({}, 'SonataPageBundle')}}</a></li>
+                                    <li><a href="{{ path('homepage', {'_switch_user': '_exit'}) }}">{{ "header.switch_user_exit"|trans({}, 'SonataPageBundle')}}</a></li>
                                 {% endif %}
 
                             </ul>


### PR DESCRIPTION
Replaced "url" with "path" in twig templates.

Problem was that in development environment URLs generated by url
function were pointing to production instance when site entity property
"host" was set to production host name. This was causing confusion when
using certain links on different than production environment.
