### PR TITLE
custom SnapshotAdminController, simplified publication process of sin…

### DIFF
--- a/Controller/SnapshotAdminController.php
+++ b/Controller/SnapshotAdminController.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symbio\OrangeGate\PageBundle\Controller;
+
+use Sonata\AdminBundle\Controller\CRUDController as Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Sonata\PageBundle\Controller\SnapshotAdminController as BaseController;
+
+/**
+ * Snapshot Admin Controller.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+class SnapshotAdminController extends BaseController
+{
+    /**
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     */
+    public function createAction(Request $request = null)
+    {
+        if (false === $this->admin->isGranted('CREATE')) {
+            throw new AccessDeniedException();
+        }
+
+        $class = $this->get('sonata.page.manager.snapshot')->getClass();
+
+        $pageManager = $this->get('sonata.page.manager.page');
+
+        $snapshot = new $class();
+
+
+        if ($request->getMethod() == 'GET' && $request->get('pageId')) {
+            $page = $pageManager->findOneBy(array('id' => $request->get('pageId')));
+        } elseif ($this->admin->isChild()) {
+            $page = $this->admin->getParent()->getSubject();
+        } else {
+            $page = null; // no page selected ...
+        }
+
+        $snapshot->setPage($page);
+
+        if ($request->getMethod() == 'GET' && $request->query->get('pageId', null) && $request->query->get('create', false)) {
+            $snapshotManager = $this->get('sonata.page.manager.snapshot');
+            $transformer = $this->get('sonata.page.transformer');
+
+            $page->setEdited(false);
+            $snapshot = $transformer->create($page);
+            $this->admin->create($snapshot);
+            $pageManager->save($page);
+            $snapshotManager->enableSnapshots(array($snapshot));
+
+            $this->addFlash('sonata_flash_success', $this->admin->trans('flash_snapshots_created_success'));
+
+            return new RedirectResponse($request->headers->get('referer'));
+        }
+
+
+        $form = $this->createForm('sonata_page_create_snapshot', $snapshot);
+
+        if ($request->getMethod() == 'POST') {
+            $form->submit($request);
+
+            if ($form->isValid()) {
+                $snapshotManager = $this->get('sonata.page.manager.snapshot');
+                $transformer = $this->get('sonata.page.transformer');
+
+                $page = $form->getData()->getPage();
+                $page->setEdited(false);
+
+                $snapshot = $transformer->create($page);
+
+                $this->admin->create($snapshot);
+
+                $pageManager->save($page);
+
+                $snapshotManager->enableSnapshots(array($snapshot));
+            }
+
+            return $this->redirect($this->admin->generateUrl('edit', array(
+                'id' => $snapshot->getId(),
+            )));
+        }
+
+        return $this->render('SonataPageBundle:SnapshotAdmin:create.html.twig', array(
+            'action'  => 'create',
+            'form'    => $form->createView(),
+        ));
+    }
+}

--- a/DependencyInjection/Compiler/SetSnapshotAdminTemplateCompilerPass.php
+++ b/DependencyInjection/Compiler/SetSnapshotAdminTemplateCompilerPass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symbio\OrangeGate\PageBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+class SetSnapshotAdminTemplateCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('sonata.page.admin.snapshot')) {
+            $definition = $container->getDefinition('sonata.page.admin.snapshot');
+            $definition->addMethodCall('setTemplate', array('list','SymbioOrangeGatePageBundle:SnapshotAdmin:list.html.twig'));
+        }
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,7 +11,7 @@ services:
             - [ setCacheManager, [ @sonata.cache.manager ] ]
             - [ setSitePool, [ @orangegate.site.pool ] ]
             - [ setTranslationDomain, [ %sonata.page.admin.page.translation_domain% ] ]
-            - [ setTemplates, [[ SonataPageBundle:PageAdmin:list.html.twig ]] ]
+            - [ setTemplates, [{SonataPageBundle:PageAdmin:list.html.twig, edit: SymbioOrangeGatePageBundle:PageAdmin:edit.html.twig }] ]
 
     sonata.page.admin.block:
             class: %sonata.page.admin.block.class%

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,7 +11,7 @@ services:
             - [ setCacheManager, [ @sonata.cache.manager ] ]
             - [ setSitePool, [ @orangegate.site.pool ] ]
             - [ setTranslationDomain, [ %sonata.page.admin.page.translation_domain% ] ]
-            - [ setTemplates, [{SonataPageBundle:PageAdmin:list.html.twig, edit: SymbioOrangeGatePageBundle:PageAdmin:edit.html.twig }] ]
+            - [ setTemplates, [{ list: SonataPageBundle:PageAdmin:list.html.twig, edit: SymbioOrangeGatePageBundle:PageAdmin:edit.html.twig } ] ]
 
     sonata.page.admin.block:
             class: %sonata.page.admin.block.class%

--- a/Resources/views/Button/publish_button.html.twig
+++ b/Resources/views/Button/publish_button.html.twig
@@ -1,0 +1,5 @@
+{% if admin.id(object) and admin.child('sonata.page.admin.snapshot').isGranted('CREATE') %}
+    <a class="btn btn-default sonata-action-element" href="{{ admin.child('sonata.page.admin.snapshot').generateUrl('create', {'pageId': object.id, 'create': 1}) }}">
+        <i class="fa fa-cloud-upload "></i>
+        {{ 'orangegate.link_action_publish'|trans }}</a>
+{% endif %}

--- a/Resources/views/PageAdmin/compose.html.twig
+++ b/Resources/views/PageAdmin/compose.html.twig
@@ -14,7 +14,7 @@
         {% include 'SymbioOrangeGateAdminBundle:Button:show_button.html.twig' %}
         {% include 'SymbioOrangeGateAdminBundle:Button:history_button.html.twig' %}
         {% if admin.child('sonata.page.admin.snapshot').isGranted('CREATE')%}
-            {% include 'SymbioOrangeGateAdminBundle:Button:publish_button.html.twig' %}
+            {% include 'SymbioOrangeGatePageBundle:Button:publish_button.html.twig' %}
         {% endif %}
         {% include 'SymbioOrangeGateAdminBundle:Button:acl_button.html.twig' %}
     {% endspaceless %}</div>

--- a/Resources/views/PageAdmin/compose.html.twig
+++ b/Resources/views/PageAdmin/compose.html.twig
@@ -13,6 +13,9 @@
     <div class="btn-group">{% spaceless %}
         {% include 'SymbioOrangeGateAdminBundle:Button:show_button.html.twig' %}
         {% include 'SymbioOrangeGateAdminBundle:Button:history_button.html.twig' %}
+        {% if admin.child('sonata.page.admin.snapshot').isGranted('CREATE')%}
+            {% include 'SymbioOrangeGateAdminBundle:Button:publish_button.html.twig' %}
+        {% endif %}
         {% include 'SymbioOrangeGateAdminBundle:Button:acl_button.html.twig' %}
     {% endspaceless %}</div>
     {#% include 'SymbioOrangeGateAdminBundle:Button:list_button.html.twig' %#}

--- a/Resources/views/PageAdmin/edit.html.twig
+++ b/Resources/views/PageAdmin/edit.html.twig
@@ -1,0 +1,13 @@
+{% extends 'SymbioOrangeGateAdminBundle:CRUD:base_edit.html.twig' %}
+
+{% block actions %}
+    <div class="btn-group">{% spaceless %}
+            {% include 'SymbioOrangeGateAdminBundle:Button:show_button.html.twig' %}
+            {% include 'SymbioOrangeGateAdminBundle:Button:history_button.html.twig' %}
+            {% if admin.child('sonata.page.admin.snapshot').isGranted('CREATE')%}
+                {% include 'SymbioOrangeGatePageBundle:Button:publish_button.html.twig' %}
+            {% endif %}
+            {% include 'SymbioOrangeGateAdminBundle:Button:acl_button.html.twig' %}
+        {% endspaceless %}</div>
+    {#% include 'SymbioOrangeGateAdminBundle:Button:list_button.html.twig' %#}
+{% endblock %}

--- a/Resources/views/SnapshotAdmin/list.html.twig
+++ b/Resources/views/SnapshotAdmin/list.html.twig
@@ -1,0 +1,4 @@
+{% extends 'SymbioOrangeGateAdminBundle:CRUD:list.html.twig' %}
+
+{% block actions %}
+{% endblock %}

--- a/SymbioOrangeGatePageBundle.php
+++ b/SymbioOrangeGatePageBundle.php
@@ -12,6 +12,7 @@ namespace Symbio\OrangeGate\PageBundle;
 
 use Symbio\OrangeGate\PageBundle\DependencyInjection\Compiler\AddSitePoolCompilerPass;
 use Symbio\OrangeGate\PageBundle\DependencyInjection\Compiler\CreateSnapshotConsumerCompilerPass;
+use Symbio\OrangeGate\PageBundle\DependencyInjection\Compiler\SetSnapshotAdminTemplateCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -40,5 +41,6 @@ class SymbioOrangeGatePageBundle extends Bundle
     {
         $container->addCompilerPass(new AddSitePoolCompilerPass());
         $container->addCompilerPass(new CreateSnapshotConsumerCompilerPass());
+        $container->addCompilerPass(new SetSnapshotAdminTemplateCompilerPass());
     }
 }


### PR DESCRIPTION
I created custom SnapshotAdminController, which inherits from sonata SnapshotAdminController and simplified publication process of single page through one publish button. I also included publish button to compose template.

Important note:
This pull request is tied with pull request in orangegate4-admin-bundle
