### PR TITLE
Changed match method of CMS router. Now it handles hybrid pages as well.

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -252,6 +252,7 @@ class PageAdmin extends BaseAdmin
 
         $formMapper
             ->with($this->trans('form_page.group_advanced_label'), array('collapsed' => false))
+                ->add('routeName', null, array('required' => true))
                 ->add('pageAlias', null, array('required' => false))
                 ->add('javascript', null,  array('required' => false))
                 ->add('stylesheet', null, array('required' => false))
@@ -276,8 +277,6 @@ class PageAdmin extends BaseAdmin
         $admin = $this->isChild() ? $this->getParent() : $this;
 
         $id = $admin->getRequest()->get('id');
-
-        $current_route = $admin->getRequest()->get('_route');
 
         $editNode = $menu->addChild(
             $this->trans('sidemenu.link_edit_page'),
@@ -352,6 +351,10 @@ class PageAdmin extends BaseAdmin
     public function getNewInstance()
     {
         $instance = parent::getNewInstance();
+
+        if (!$instance->getRouteName()) {
+            $instance->setRouteName(PageInterface::PAGE_ROUTE_CMS_NAME);
+        }
 
         if (!$this->hasRequest()) {
             return $instance;

--- a/Entity/PageManager.php
+++ b/Entity/PageManager.php
@@ -29,39 +29,35 @@ class PageManager extends BasePageManager implements PageManagerInterface
             return;
         }
 
-        // hybrid page cannot be altered
-        if (!$page->isHybrid()) {
+        // make sure Page has a valid url
+        if ($page->getParent()) {
+            foreach ($page->getTranslations() as $trans) {
+                $locale = $trans->getLocale();
 
-            // make sure Page has a valid url
-            if ($page->getParent()) {
-                foreach ($page->getTranslations() as $trans) {
-                    $locale = $trans->getLocale();
+                if (!$trans->getSlug()) {
+                    $trans->setSlug(ModelPage::slugify($trans->getName()));
+                }
 
-                    if (!$trans->getSlug()) {
-                        $trans->setSlug(ModelPage::slugify($trans->getName()));
+                $parent = $page->getParent();
+                $ptrans = $parent->getTranslation($locale);
+
+                if ($ptrans) {
+                    $url = $ptrans->getUrl();
+                    if ($url == '/') {
+                        $base = '/';
+                    } elseif (substr($url, -1) != '/') {
+                        $base = $url . '/';
+                    } else {
+                        $base = $url;
                     }
 
-                    $parent = $page->getParent();
-                    foreach ($parent->getTranslations() as $ptrans) {
-                        if ($ptrans->getLocale() === $locale) {
-                            $url = $ptrans->getUrl();
-                            if ($url == '/') {
-                                $base = '/';
-                            } elseif (substr($url, -1) != '/') {
-                                $base = $url . '/';
-                            } else {
-                                $base = $url;
-                            }
-
-                            $trans->setUrl($base . $trans->getSlug());
-                        }
-                    }
+                    $trans->setUrl($base . $trans->getSlug());
                 }
-            } else {
-                foreach ($page->getTranslations() as $trans) {
-                    // a parent page does not have any slug - can have a custom url ...
-                    $trans->setUrl('/' . $trans->getSlug());
-                }
+            }
+        } else {
+            foreach ($page->getTranslations() as $trans) {
+                // a parent page does not have any slug - can have a custom url ...
+                $trans->setUrl('/' . $trans->getSlug());
             }
         }
 

--- a/Resources/translations/SonataPageBundle.cs.xliff
+++ b/Resources/translations/SonataPageBundle.cs.xliff
@@ -154,6 +154,7 @@
         <source>form.label_decorate</source>
         <target>Dekorovat</target>
       </trans-unit>
+
       <trans-unit id="39">
         <source>Enabled</source>
         <target>Povoleno</target>
@@ -810,6 +811,10 @@
       <trans-unit id="form.label_note">
         <source>form.label_note</source>
         <target>Poznámka</target>
+      </trans-unit>
+      <trans-unit id="form.label_route_name">
+        <source>form.label_route_name</source>
+        <target>Akce stránky</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
- Hybrid pages are handled through CmsPageHandler like any other CMS pages.
- RouteName field added to admin form and generating URL in CMS now accepts hybrid pages as well.
- Be sure to use page instead of route name in generating URLs.
